### PR TITLE
fixed exportWorkspace to do a GET call instead of a POST

### DIFF
--- a/databricksapi/Workspace.py
+++ b/databricksapi/Workspace.py
@@ -27,7 +27,7 @@ class Workspace(Databricks.Databricks):
 			'direct_download': direct_download
 		}
 
-		return self._post(url, payload)
+		return self._get(url, payload)
 
 
 	def getWorkspaceStatus(self, path):


### PR DESCRIPTION
Hi 

I was testing some functionality on using this API and I found that `exportWorkspace` did not work.  looking a bit into it, I found that is making a POST call when it is supposed to do a GET call (https://docs.databricks.com/api/latest/workspace.html#export).

I also found that using the flag `direct_download` causes an error (as it returns a string, but the library tries to read it as a json). I did not fix that one with this commit