### PR TITLE
bugfix: createGroup endpoint value

### DIFF
--- a/databricksapi/Groups.py
+++ b/databricksapi/Groups.py
@@ -30,7 +30,7 @@ class Groups(Databricks.Databricks):
 		return self._post(url, payload)
 
 	def createGroup(self, group_name):
-		endpoint = 'group'
+		endpoint = 'create'
 		url = self._set_url(self._url, self._api_type, endpoint)
 
 		payload = {


### PR DESCRIPTION
updated the endpoint value for createGroup function as it was set to `group` but should be `create`